### PR TITLE
Update function parameter naming for new Swift style

### DIFF
--- a/style-guidelines/Swift.md
+++ b/style-guidelines/Swift.md
@@ -57,8 +57,8 @@ For functions and init methods, prefer named parameters for all arguments unless
 
 ```swift
 func dateFromString(dateString: String) -> NSDate { ... }
-func convertPointAt(#column: Int, #row: Int) -> CGPoint { ... }
-func timedAction(#delay: NSTimeInterval, perform action: SKAction) -> SKAction! { ... }
+func convertPointAt(column column: Int, row: Int) -> CGPoint { ... }
+func timedAction(delay delay: NSTimeInterval, perform action: SKAction) -> SKAction! { ... }
 
 // would be called like this:
 dateFromString("2014-03-14") { ... }


### PR DESCRIPTION
Functions now behave the same way as methods. # sign is deprecated now :)
