### PR TITLE
Improve merging guidelines

### DIFF
--- a/GIT_AND_GITHUB.md
+++ b/GIT_AND_GITHUB.md
@@ -75,7 +75,7 @@ submitter and go through the pull request together.
 Be warned, though: By doing this, you will both need to explain your thoughts and
 discuss other alternatives. Of course, this means you are putting yourself at risk
 of sharing your knowledge and/or learning some new stuff, so please be careful not
-to end up being even more awesome than you are.
+to end up being even more awesome than you already are.
 
 As a reviewer your job is to be the extra pair of eyes, so the code will get twice 
 as good. You will look at thing like code style, structure, discuss things you might 

--- a/GIT_AND_GITHUB.md
+++ b/GIT_AND_GITHUB.md
@@ -77,6 +77,28 @@ discuss other alternatives. Of course, this means you are putting yourself at ri
 of sharing your knowledge and/or learning some new stuff, so please be careful not
 to end up being even more awesome than you are.
 
+As a reviewer your job is to be the extra pair of eyes, so the code will get twice 
+as good. You will look at thing like code style, structure, discuss things you might 
+do differently, point out what you've recently learned or applied. The goal is to 
+make the whole team become better at what we do!
+
+Keep in mind that you are reviewing what someone worked on really hard, so always be 
+respectful. The guidelines from github for giving feedback are a good reference:
+
+> - Familiarize yourself with the context of the issue, and reasons why this Pull Request exists.
+> - If you disagree strongly, consider giving it a few minutes before responding; think before you react.
+> - Ask, don’t tell. (“What do you think about trying…?” rather than “Don’t do…”)
+> - Explain your reasons why code should be changed. (Not in line with the style guide? A personal preference?)
+> - Offer ways to simplify or improve code.
+> - Avoid using derogatory terms, like “stupid”, when referring to the work someone has produced.
+> - Be humble. (“I’m not sure, let’s try…”)
+> - Avoid hyperbole. (“NEVER do…”)
+> - Aim to develop professional skills, group knowledge and product quality, through group critique.
+> - Be aware of negative bias with online communication. (If content is neutral, we assume the tone is negative.) Can you use positive language as opposed to neutral?
+> - Use emoji to clarify tone. Compare “✨ ✨ Looks good 👍 ✨ ✨” to “Looks good.”
+
+*source: [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)
+
 If everything is fine feel free to merge the pull request. Avoid merging before receiving
 a feedback. If several developers are involved in the project, one confirmation should be 
 enough. You can always submit subsequent pull requests or file an issue after the fact.

--- a/GIT_AND_GITHUB.md
+++ b/GIT_AND_GITHUB.md
@@ -78,9 +78,10 @@ of sharing your knowledge and/or learning some new stuff, so please be careful n
 to end up being even more awesome than you already are.
 
 As a reviewer your job is to be the extra pair of eyes, so the code will get twice 
-as good. You will look at thing like code style, structure, discuss things you might 
-do differently, point out what you've recently learned or applied. The goal is to 
-make the whole team become better at what we do!
+as good. You'll look at things such as code style and structure. You'll discuss things 
+that you might've done differently, point out possible more elegant solutions based 
+on something you've learned, and so on. The goal here is to make the whole team better 
+in the process.
 
 Keep in mind that you are reviewing what someone worked on really hard, so always be 
 respectful. The guidelines from GitHub for giving feedback are a good reference:

--- a/GIT_AND_GITHUB.md
+++ b/GIT_AND_GITHUB.md
@@ -97,7 +97,7 @@ respectful. The guidelines from GitHub for giving feedback are a good reference:
 > - Be aware of negative bias with online communication. (If content is neutral, we assume the tone is negative.) Can you use positive language as opposed to neutral?
 > - Use emoji to clarify tone. Compare “✨ ✨ Looks good 👍 ✨ ✨” to “Looks good.”
 
-*source: [How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)
+[Source: How to write the perfect pull request](https://github.com/blog/1943-how-to-write-the-perfect-pull-request)
 
 If everything is fine feel free to merge the pull request. Avoid merging before receiving
 a feedback. If several developers are involved in the project, one confirmation should be 

--- a/GIT_AND_GITHUB.md
+++ b/GIT_AND_GITHUB.md
@@ -83,8 +83,9 @@ that you might've done differently, point out possible more elegant solutions ba
 on something you've learned, and so on. The goal here is to make the whole team better 
 in the process.
 
-Keep in mind that you are reviewing what someone worked on really hard, so always be 
-respectful. The guidelines from GitHub for giving feedback are a good reference:
+Keep in mind that you are reviewing something that someone else has worked on really 
+hard, so always be respectful. The guidelines from GitHub for giving feedback are a 
+good reference:
 
 > - Familiarize yourself with the context of the issue, and reasons why this Pull Request exists.
 > - If you disagree strongly, consider giving it a few minutes before responding; think before you react.

--- a/GIT_AND_GITHUB.md
+++ b/GIT_AND_GITHUB.md
@@ -83,7 +83,7 @@ do differently, point out what you've recently learned or applied. The goal is t
 make the whole team become better at what we do!
 
 Keep in mind that you are reviewing what someone worked on really hard, so always be 
-respectful. The guidelines from github for giving feedback are a good reference:
+respectful. The guidelines from GitHub for giving feedback are a good reference:
 
 > - Familiarize yourself with the context of the issue, and reasons why this Pull Request exists.
 > - If you disagree strongly, consider giving it a few minutes before responding; think before you react.

--- a/GIT_AND_GITHUB.md
+++ b/GIT_AND_GITHUB.md
@@ -9,8 +9,8 @@ purposes, as to avoid having `dev`, `development`, `staging`, `wip` and others.
 
 You might be wondering: why only `master`? What if I have to rollback to apply
 a fix? Well, if you find a bug in a previous release, you can just, checkout the tag,
- fork it, fix it, deploy the new build, and finally, submit a PR to merge it with `master`
-  to the sound of Daft Punk.
+fork it, fix it, deploy the new build, and finally, submit a PR to merge it with `master`
+to the sound of Daft Punk.
 
 Commit messages are in the [imperative present tense](http://stackoverflow.com/questions/3580013/should-i-use-past-or-present-tense-in-git-commit-messages), and have no period at the end.
 
@@ -57,22 +57,10 @@ Besides, a description with more information could be helpful, for example:
 - If it's an interaction, a gif would help a lot. A good tool to make gifs is [Licecap](http://www.cockos.com/licecap/).
 - If it's a bug, steps to reproduce are very useful to help understanding context.
 
-#### When to merge a pull request?
-
 Before merging a pull request, your code has to be reviewed, so that we can learn from you, 
 point out your silly mistakes, and/or post a sufficient amount of gifs. The reviewing
 process is important. It is better for you to have another person backing you up. More eyes
 can mean less bugs and more consistency throughout.
-
-When the reviewer signs off, confirming that the changes are ready, feel free to 
-merge your pull request. Avoid merging before receiving a confirmation, even for 
-"final fixes" and "last touches". If several developers are involved in the project,
-one confirmation should be enough. You can always submit subsequent pull requests or file an issue after the fact.
-
-As a reviewer, when signing off on an issue, be sure to be as explicit and unambiguous as possible.
-
-After you have merged, you should delete the branch and smile. The smile is critical 
-part of the process, so don't forget this.
 
 #### Reviewing pull requests
 
@@ -88,6 +76,13 @@ Be warned, though: By doing this, you will both need to explain your thoughts an
 discuss other alternatives. Of course, this means you are putting yourself at risk
 of sharing your knowledge and/or learning some new stuff, so please be careful not
 to end up being even more awesome than you are.
+
+If everything is fine feel free to merge the pull request. Avoid merging before receiving
+a feedback. If several developers are involved in the project, one confirmation should be 
+enough. You can always submit subsequent pull requests or file an issue after the fact.
+
+After you have merged, you should delete the branch and smile. The smile is critical 
+part of the process, so don't forget this.
 
 #### My pull request depends on another pending pull request. What to do?
 


### PR DESCRIPTION
Improve merging guidelines so it works for:
- Our own repositories
- Our private repositories
- External repositories that we contribute
