### PR TITLE
Update git commit guidelines.

### DIFF
--- a/GIT_AND_GITHUB.md
+++ b/GIT_AND_GITHUB.md
@@ -8,14 +8,12 @@ The `master` branch is the stable branch. It's also used for development
 purposes, as to avoid having `dev`, `development`, `staging`, `wip` and others.
 
 You might be wondering: why only `master`? What if I have to rollback to apply
-a fix? Well, if you find a bug in a previous release, you can just, checkout the tag,
+a fix? Well, if you find a bug in a previous release, you can checkout the tag,
 fork it, fix it, deploy the new build, and finally, submit a PR to merge it with `master`
 to the sound of Daft Punk.
 
-Commit messages are in the [imperative present tense](http://stackoverflow.com/questions/3580013/should-i-use-past-or-present-tense-in-git-commit-messages), and have no period at the end.
-
-Prefer concise commits over gigantic ones. When writing a concise commit message
-is difficult, it may indicate too many unrelated changes.
+Commit messages should be consise and descriptive. If writing a concise commit message
+is difficult, it may be indicative that too many unrelated changes are bundled together. If that's the case, split it into smaller commits.
 
 Feel free to elaborate more on the commit description.
 


### PR DESCRIPTION
Since we now use squash and merge for every PR, the commit messages themselves serve only during the pull request phase and are discarded once the PR is closed. Makes no sense having strict rules for commit messages anymore. Just make them concise and descriptive.