### PR TITLE
Better handling of checking if a variable changed

### DIFF
--- a/BEST_PRACTICES.md
+++ b/BEST_PRACTICES.md
@@ -317,21 +317,13 @@ The other solution would be that the `PhotoViewerController` takes care of this 
 ```swift
 // PhotoViewerController
 
-var changed = false
 var photo: Photo? {
-    willSet {
-        if photo?.id != newValue?.id {
-            changed = true
-        }
-    }
-
     didSet {
         guard let photo = photo else { return }
 
-        if changed {
+        if photo.id != oldValue?.id  {
             // Do something with photo, maybe download and so on
-            changed = false
-        }
+        } //else, the photo has remained the same.
     }
 }
 ```


### PR DESCRIPTION
Our current code standards recommend doing a bunch of extra work that is covered by the `oldValue` variable you can access within the `didSet` closure. Here is an example of this in action: 

![screen shot 2017-11-29 at 10 37 37 am](https://user-images.githubusercontent.com/1976498/33368270-8121aa3a-d4f1-11e7-9fe1-4b0313754bf5.png)

This update proposes changing the recommended method to use `oldValue`.